### PR TITLE
[CuidoMiCiudad] Show area breakdown on /reports page

### DIFF
--- a/templates/web/cuidomiciudad/reports/_extras.html
+++ b/templates/web/cuidomiciudad/reports/_extras.html
@@ -1,0 +1,10 @@
+[% FOR area IN body.first_area_children(c).values.sort('name') %]
+    <tr align="center" class="table-row__child_area">
+        <td class="title"><a href="[% body.url(c) %]/[% area.name | uri %]">[% area.name %]</a></td>
+        <td class="data">[% IF open.areas.${area.id}.new %]<a href="[% body.url(c) %]/[% area.name | uri %]?t=new">[% open.areas.${area.id}.new %]</a>[% ELSE %]0[% END %]</td>
+        <td class="data">[% IF open.areas.${area.id}.older %]<a href="[% body.url(c) %]/[% area.name | uri %]?t=older">[% open.areas.${area.id}.older %]</a>[% ELSE %]0[% END %]</td>
+        <td class="data">[% IF open.areas.${area.id}.unknown %]<a href="[% body.url(c) %]/[% area.name | uri %]?t=unknown">[% open.areas.${area.id}.unknown %]</a>[% ELSE %]0[% END %]</td>
+        <td class="data">[% IF fixed.areas.${area.id}.new %]<a href="[% body.url(c) %]/[% area.name | uri %]?t=fixed">[% fixed.areas.${area.id}.new %]</a>[% ELSE %]0[% END %]</td>
+        <td class="data">[% IF fixed.areas.${area.id}.old %]<a href="[% body.url(c) %]/[% area.name | uri %]?t=older_fixed">[% fixed.areas.${area.id}.old %]</a>[% ELSE %]0[% END %]</td>
+    </tr>
+[% END %]

--- a/web/cobrands/cuidomiciudad/base/_content.scss
+++ b/web/cobrands/cuidomiciudad/base/_content.scss
@@ -16,4 +16,18 @@
     body.mappage & {
         padding: 0 1em;
     }
+
+    table.nicetable {
+        tr.a {
+            background: transparent;
+        }
+
+        tr:nth-child(even) {
+            background-color: #f6f6f6;
+        };
+    }
+
+    tr.table-row__child_area .title {
+        padding-left: 1em;
+    }
 }


### PR DESCRIPTION
All areas covered by the Distrito Nacional are shown individually on the reports table:

<img width="972" alt="screen shot 2017-06-21 at 13 50 36" src="https://user-images.githubusercontent.com/4776/27384953-c95e44e4-5688-11e7-8cc3-bc0d68ef2259.png">

Individual areas' maps can be viewed:
![screen shot 2017-06-21 at 13 51 41](https://user-images.githubusercontent.com/4776/27384982-ea745b78-5688-11e7-9656-131d8a5845b3.png)

As well as the Distrito as a whole:
![screen shot 2017-06-21 at 13 51 43](https://user-images.githubusercontent.com/4776/27384994-f3d45ac4-5688-11e7-83e7-773009eea6e7.png)



Fixes mysociety/fixmystreet-commercial#855.