### PR TITLE
Allow locale file overriding per cobrand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/locale
 *.ttc
 web/cobrands/*/*.css
 web/cobrands/*/*.css.map

--- a/bin/create-cobrand-symlinks
+++ b/bin/create-cobrand-symlinks
@@ -18,6 +18,15 @@ LN_FLAGS="-s -f -v"
 
 echo "Creating symlinks in $(pwd):"
 
+LOCALE_SOURCE_DIR=fixmystreet-international/locale
+LOCALE_TARGET_DIR=locale
+for lang_dir in $(pwd)/$LOCALE_SOURCE_DIR/*; do
+    lang=$(basename $lang_dir)
+    for source in $lang_dir/LC_MESSAGES/*.po; do
+        ln $LN_FLAGS $source $LOCALE_TARGET_DIR/$lang/LC_MESSAGES/
+    done
+done
+
 PERL_MODULES_SOURCE_DIR=fixmystreet-international/perllib/FixMyStreet/Cobrand
 PERL_MODULES_TARGET_DIR=perllib/FixMyStreet/Cobrand
 for cobrand in $(pwd)/$PERL_MODULES_SOURCE_DIR/*pm; do
@@ -52,4 +61,6 @@ ln $LN_FLAGS ../../../$WEB_ASSETS_TARGET_DIR/fixmystreet .
 cd ../../..
 
 echo "Cleaning up removed cobrands"
-find $PERL_MODULES_TARGET_DIR $WEB_TEMPLATES_TARGET_DIR $EMAIL_TEMPLATES_TARGET_DIR $WEB_ASSETS_TARGET_DIR -maxdepth 1 -type l -exec test ! -e {} \; -print -delete
+find $LOCALE_TARGET_DIR $PERL_MODULES_TARGET_DIR $WEB_TEMPLATES_TARGET_DIR \
+    $EMAIL_TEMPLATES_TARGET_DIR $WEB_ASSETS_TARGET_DIR \
+    -maxdepth 1 -type l -exec test ! -e {} \; -print -delete

--- a/bin/create-po-files
+++ b/bin/create-po-files
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# abort on any errors
+set -e
+
+# Allow null globs, to prevent weird file creation
+shopt -s nullglob
+
+# check that we are in the expected directory
+cd `dirname $0`/../..
+
+echo "Creating merged po files:"
+
+LOCALE_SOURCE_DIR=locale
+LOCALE_CHANGE_DIR=fixmystreet-international/locale_changes
+LOCALE_TARGET_DIR=fixmystreet-international/locale
+for lang_dir in $LOCALE_CHANGE_DIR/*; do
+    lang=$(basename "$lang_dir")
+    for changes in $lang_dir/LC_MESSAGES/*.po; do
+        fn=$(basename "$changes")
+        out=$LOCALE_TARGET_DIR/$lang/LC_MESSAGES/$fn
+        source=$LOCALE_SOURCE_DIR/$lang/LC_MESSAGES/FixMyStreet.po
+        msgcat --no-wrap --use-first -o $out $changes $source
+        echo "Merged $lang locale…FixMyStreet.po + locale_changes…$fn to international’s locale…$fn"
+    done
+done

--- a/locale_changes/es_DO.UTF-8/LC_MESSAGES/YoDenuncio.po
+++ b/locale_changes/es_DO.UTF-8/LC_MESSAGES/YoDenuncio.po
@@ -1,0 +1,38 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: 1.0\n"
+"POT-Creation-Date: 2017-12-15 17:48+0000\n"
+"PO-Revision-Date: 2018-01-01 00:00+0000\n"
+"Last-Translator: mySociety <transifex@mysociety.org>, 2017\n"
+"Language-Team: Spanish (Dominican Republic) (https://www.transifex.com/mysociety/teams/12067/es_DO/)\n"
+"Language: es_DO\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: templates/web/base/status/stats.html:27
+#: templates/web/zurich/admin/index.html:6
+msgid "%s council contacts &ndash; %s confirmed, %s unconfirmed"
+msgstr "%s contactos en Policía Nacional – Ministerio Público &ndash; %s confirmados, %s sin confirmar"
+
+#: templates/web/base/admin/list_updates.html:9
+msgid "Council"
+msgstr "Policía Nacional – Ministerio Público"
+
+#: templates/web/base/dashboard/index.html:50
+msgid "Council:"
+msgstr "Policía Nacional – Ministerio Público:"
+
+#: perllib/FixMyStreet/DB/ResultSet/State.pm:66
+msgid "Fixed - Council"
+msgstr "Arreglado - Policía Nacional – Ministerio Público"
+
+#: templates/web/base/report/new/councils_text_private.html:5
+#: templates/web/base/report/new/form_user.html:4
+msgid "These will be sent to the council, but will never be shown online."
+msgstr "Estos serán enviados a la Policía Nacional o el Ministerio Publico, pero nunca se mostrarán en linea."
+
+#: templates/web/base/report/new/form_report.html:58
+msgid "This pothole has been here for two months and…"
+msgstr "Es muy importante que tu denuncia contenga el día, la hora y el lugar de los hechos. Una descripción detallada del evento, incluyendo información pertinente sobre los delincuentes y los artículos sustraídos, nos ayudará a realizar una mejor investigación."

--- a/perllib/FixMyStreet/Cobrand/YoDenuncio.pm
+++ b/perllib/FixMyStreet/Cobrand/YoDenuncio.pm
@@ -10,6 +10,7 @@ sub country {
 
 sub languages { [ 'es-do,Spanish,es_DO' ] }
 sub language_override { 'es-do' }
+sub language_domain { 'YoDenuncio' }
 
 sub admin_allow_user {
     my ( $self, $user ) = @_;


### PR DESCRIPTION
This lets a cobrand have its own .po file, merged with the new script, then symlinked with the existing script, and turns that on for YoDenuncio.