### PR TITLE
Change UKCOD to mySociety

### DIFF
--- a/templates/email/cuidomiciudad/submit-example.txt
+++ b/templates/email/cuidomiciudad/submit-example.txt
@@ -46,7 +46,7 @@ Replies to this email will go to the user who submitted the problem.
 Yours,  
 The FixMyStreet team
 
-This message was sent via FixMyStreet, a project of UKCOD,
+This message was sent via FixMyStreet, a project of mySociety,
 registered charity number 1076346. If there is a more appropriate
 email address for messages about 'Potholes', please let us know by
 visiting <https://www.fixmystreet.com/contact>. This will help


### PR DESCRIPTION
I don't actually know if this is crucial / the site is still in use, but this commit updates the company name from UKCOD to mySociety in line with changes I've submitted to the same template in the main FMS codebase.